### PR TITLE
Resolve SSH timeout by setting up OCI Bastion

### DIFF
--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -1,0 +1,17 @@
+# Bastion Service
+resource "oci_bastion_bastion" "news_check_bastion" {
+  bastion_type                 = "STANDARD"
+  compartment_id               = var.compartment_ocid
+  target_subnet_id             = oci_core_subnet.news_check_public_subnet.id
+  client_cidr_block_allow_list = ["0.0.0.0/0"] # We can restrict this if needed, but Cloud Shell IPs are dynamic
+  name                         = "${var.project_name}-bastion"
+
+  freeform_tags = {
+    "Project"     = var.project_name
+    "Environment" = var.environment
+  }
+}
+
+output "bastion_ocid" {
+  value = oci_bastion_bastion.news_check_bastion.id
+}


### PR DESCRIPTION
Close #5. Added OCI Bastion Service to enable secure SSH access from Cloud Shell without opening port 22 to the internet. This PR adds the  file and configured the Bastion service in the production environment.