### PR TITLE
Allow public SSH access and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,29 @@ graph TD
 
     成功すると、処理結果 (処理件数など) がJSON形式で返却されます。
 
+## 🌐 インフラ操作と接続 (Infrastructure & Operation)
+
+本プロジェクトは OCI (Oracle Cloud Infrastructure) 上で稼働しています。
+
+### インスタンスへの SSH 接続
+
+開発者向けの SSH 接続手順です。セキュリティ・リストでポート 22 を開放している場合、以下のコマンドで直接ログインできます。
+
+```bash
+# WSL (Ubuntu) 等のローカル環境から接続
+ssh -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa -i ~/.ssh/id_rsa ubuntu@150.230.3.83
+```
+
+> **Note**: 古い RSA キーを使用している、または OpenSSH の最新バージョンを使用している場合に備え、アルゴリズムを明示的に指定しています。
+
+### ログの確認
+
+アプリケーションの動作ログ（初期構築時の cloud-init 等）を確認するには、ログイン後に以下のコマンドを実行します。
+
+```bash
+tail -f /var/log/cloud-init-output.log
+```
+
 ## 📂 プロジェクト構成
 
 ```text

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -55,13 +55,12 @@ resource "oci_core_security_list" "news_check_security_list" {
     stateless   = false
   }
 
-  # Ingress Rule: SSH (22) - Internal Access Only (for self-provisioning or future expansion)
-  # 外部(Internet)からのSSHは許可しない。サーバー内部での実行を前提とするため。
+  # Ingress Rule: SSH (22) - Public Access (Temporary or Restricted as needed)
   ingress_security_rules {
     protocol    = "6" # TCP
-    source      = var.vcn_cidr_block
+    source      = "0.0.0.0/0"
     stateless   = false
-    description = "Allow SSH access from internal VCN only"
+    description = "Allow SSH access from anywhere"
 
     tcp_options {
       min = 22


### PR DESCRIPTION
Close #7. 
### 変更内容
- **terraform/network.tf**: セキュリティ・リストを更新し、SSH (ポート22) のソースを  (全許可) に変更しました。これにより、Bastionを経由せず直接SSH接続が可能になります。
- **README.md**: 正常にログインできたSSHコマンド（アルゴリズム指定付き）と、ログの確認方法を追記しました。

本番環境での動作確認（ログイン成功）済みです。