### PR TITLE
fix: 誤っていたANNnewsCHのチャンネルIDを修正

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -41,7 +41,7 @@ def collect_news(db: Session = Depends(get_db)):
         summarizer = Summarizer(os.getenv("GEMINI_API_KEY"))
 
         # ANNnewsCH のチャンネルID
-        channel_id = "UCGCZAYq59byoQDfGzU496OQ"
+        channel_id = "UCGCZAYq5Xxojl_tSXcVJhiQ"
         videos = youtube_client.search_news_videos(channel_id)
 
         # 1. YouTubeから見つかった動画をDBに保存


### PR DESCRIPTION
昨日(1/12)のAI Agentによる修正で、ANNnewsCHのチャンネルIDが誤った値（存在しないID）にハードコードされていました。これによりニュースの収集が失敗していたため、正しいID（UCGCZAYq5Xxojl_tSXcVJhiQ）に修正しました。

Close #19