### PR TITLE
feat: ニュース取得ソースをYouTubeからNHK RSSフィードに変更

### DIFF
--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -3,8 +3,8 @@ all:
     deploy_user: seiya
     ansible_user: "{{ deploy_user }}"
     project_root: "/home/{{ ansible_user }}/git/news_check"
-    gemini_api_key: "AIzaSyDh0reCRiftvayTeNXEh-QOdzo35zEY2OE"
-    youtube_api_key: "AIzaSyCDZVcQeBBEzRHHqqQHXQXfBxh14OMXW-M"
+    gemini_api_key: "{{ lookup('env', 'GEMINI_API_KEY') | default('', true) }}"
+    youtube_api_key: "{{ lookup('env', 'YOUTUBE_API_KEY') | default('', true) }}"
     next_public_api_url: ""
 
   children:

--- a/backend/database.py
+++ b/backend/database.py
@@ -29,6 +29,8 @@ class Channel(Base):
 
 
 class Video(Base):
+    """YouTube動画用モデル (旧システム、後方互換性のため残す)"""
+
     __tablename__ = "videos"
     youtube_id = Column(String, primary_key=True)
     title = Column(String, nullable=False)
@@ -53,6 +55,43 @@ class KeyPoint(Base):
     point = Column(Text, nullable=False)
 
     video = relationship("Video", back_populates="key_points")
+
+
+# =====================================================
+# NHKニュース記事用の新モデル
+# =====================================================
+
+
+class Article(Base):
+    """NHKニュース記事用モデル"""
+
+    __tablename__ = "articles"
+    article_id = Column(String, primary_key=True)
+    title = Column(String, nullable=False)
+    link = Column(String, nullable=False)
+    description = Column(Text)  # RSSのdescription (概要)
+    content = Column(Text)  # 記事本文 (スクレイピングで取得)
+    summary = Column(Text)  # Geminiによる要約
+    category = Column(String)  # ニュースカテゴリ
+    source = Column(String, default="NHK")  # ニュースソース
+    published_at = Column(DateTime(timezone=True))
+    status = Column(String, default="unprocessed")
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+    key_points = relationship(
+        "ArticleKeyPoint", back_populates="article", cascade="all, delete-orphan"
+    )
+
+
+class ArticleKeyPoint(Base):
+    """NHKニュース記事の重要ポイント"""
+
+    __tablename__ = "article_key_points"
+    id = Column(Integer, primary_key=True, index=True)
+    article_id = Column(String, ForeignKey("articles.article_id"))
+    point = Column(Text, nullable=False)
+
+    article = relationship("Article", back_populates="key_points")
 
 
 def get_db():

--- a/backend/nhk_client.py
+++ b/backend/nhk_client.py
@@ -1,0 +1,175 @@
+"""
+NHKニュースRSSフィードからニュース記事を取得するクライアント
+"""
+
+import random
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional
+
+import feedparser
+import requests
+from bs4 import BeautifulSoup
+
+
+class NHKNewsClient:
+    """NHKニュースRSSフィードからニュース記事を取得するクライアント"""
+
+    # NHK RSSフィードのURL一覧
+    RSS_FEEDS = {
+        "main": "https://www3.nhk.or.jp/rss/news/cat0.xml",  # 主要ニュース
+        "society": "https://www3.nhk.or.jp/rss/news/cat1.xml",  # 社会
+        "science": "https://www3.nhk.or.jp/rss/news/cat3.xml",  # 科学・文化
+        "politics": "https://www3.nhk.or.jp/rss/news/cat4.xml",  # 政治
+        "business": "https://www3.nhk.or.jp/rss/news/cat5.xml",  # ビジネス
+        "international": "https://www3.nhk.or.jp/rss/news/cat6.xml",  # 国際
+        "sports": "https://www3.nhk.or.jp/rss/news/cat7.xml",  # スポーツ
+    }
+
+    def __init__(self):
+        """クライアントの初期化"""
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+            }
+        )
+
+    def fetch_news(
+        self, categories: Optional[List[str]] = None, max_articles: int = 20
+    ) -> List[Dict]:
+        """
+        NHK RSSフィードからニュース記事を取得する
+
+        Args:
+            categories: 取得するカテゴリのリスト (デフォルトは主要ニュースのみ)
+            max_articles: 取得する最大記事数
+
+        Returns:
+            ニュース記事のリスト
+        """
+        if categories is None:
+            categories = ["main"]
+
+        articles = []
+        seen_urls = set()
+
+        for category in categories:
+            if category not in self.RSS_FEEDS:
+                print(f"Unknown category: {category}")
+                continue
+
+            rss_url = self.RSS_FEEDS[category]
+            print(f"Fetching RSS feed: {rss_url}")
+
+            try:
+                feed = feedparser.parse(rss_url)
+
+                if not feed.entries:
+                    print(f"No entries found in RSS feed for category: {category}")
+                    continue
+
+                for entry in feed.entries:
+                    link = entry.get("link", "")
+
+                    # 重複チェック
+                    if link in seen_urls:
+                        continue
+                    seen_urls.add(link)
+
+                    # 記事IDをURLから抽出 (例: k10015031561000)
+                    article_id = self._extract_article_id(link)
+                    if not article_id:
+                        continue
+
+                    # 公開日時をパース
+                    published_at = None
+                    if hasattr(entry, "published_parsed") and entry.published_parsed:
+                        published_at = datetime(*entry.published_parsed[:6])
+                        # タイムゾーンを付与 (JST)
+                        jst = timezone(timedelta(hours=9))
+                        published_at = published_at.replace(tzinfo=jst)
+
+                    articles.append(
+                        {
+                            "article_id": article_id,
+                            "title": entry.get("title", ""),
+                            "link": link,
+                            "description": entry.get("description", ""),
+                            "published_at": published_at,
+                            "category": category,
+                            "source": "NHK",
+                        }
+                    )
+
+                    if len(articles) >= max_articles:
+                        break
+
+            except Exception as e:
+                print(f"Error fetching RSS feed {rss_url}: {e}")
+                continue
+
+        print(f"Found {len(articles)} news articles from NHK RSS feed")
+        return articles
+
+    def fetch_article_content(self, url: str) -> Optional[str]:
+        """
+        記事ページから本文を取得する
+
+        Args:
+            url: 記事のURL
+
+        Returns:
+            記事本文のテキスト
+        """
+        try:
+            # リクエスト間隔を空ける
+            time.sleep(random.uniform(1.0, 3.0))
+
+            response = self.session.get(url, timeout=10)
+            response.raise_for_status()
+
+            soup = BeautifulSoup(response.text, "html.parser")
+
+            # NHKニュースの記事本文を取得
+            # 複数のセレクタを試す
+            content_selectors = [
+                "div.content--detail-body",
+                "div.body-content",
+                "article",
+                "div.content--summary",
+            ]
+
+            for selector in content_selectors:
+                content_div = soup.select_one(selector)
+                if content_div:
+                    # 不要な要素を削除
+                    for unwanted in content_div.select(
+                        "script, style, nav, footer, .related"
+                    ):
+                        unwanted.decompose()
+
+                    text = content_div.get_text(separator="\n", strip=True)
+                    if len(text) > 100:  # 十分な長さのテキストが取得できた場合
+                        return text
+
+            # フォールバック: 全体からテキストを抽出
+            return None
+
+        except Exception as e:
+            print(f"Error fetching article content from {url}: {e}")
+            return None
+
+    def _extract_article_id(self, url: str) -> Optional[str]:
+        """URLから記事IDを抽出する"""
+        import re
+
+        # 例: http://www3.nhk.or.jp/news/html/20260121/k10015031561000.html
+        match = re.search(r"(k\d+)\.html", url)
+        if match:
+            return match.group(1)
+
+        # URLをハッシュ化してIDとして使用
+        import hashlib
+
+        return hashlib.md5(url.encode()).hexdigest()[:16]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,5 @@ pytest
 httpx
 pytest-mock
 gunicorn
+beautifulsoup4
+lxml

--- a/backend/summarizer.py
+++ b/backend/summarizer.py
@@ -14,7 +14,7 @@ class Summarizer:
 
     def summarize(self, transcript: str) -> Dict:
         """
-        Gemini APIを使用して字幕を要約する。
+        Gemini APIを使用して字幕を要約する。(YouTube動画用)
         """
         prompt = f"""
 あなたはプロのニュース編集者です。提供された「YouTubeニュース動画のテキスト（字幕または説明文）」を解析し、視聴者が短時間で内容を把握できる高品質な要約を作成してください。
@@ -39,6 +39,38 @@ class Summarizer:
 対象のテキスト:
 {transcript}
 """
+        return self._generate_summary(prompt)
+
+    def summarize_article(self, article_text: str) -> Dict:
+        """
+        Gemini APIを使用してニュース記事を要約する。(NHKニュース等のテキスト記事用)
+        """
+        prompt = f"""
+あなたはプロのニュース編集者です。提供された「ニュース記事のテキスト」を解析し、読者が短時間で内容を把握できる高品質な要約を作成してください。
+
+【注意点】
+- 記事の具体的な「事実（事件、事故、政治、経済、気象、国際情勢など）」にのみ焦点を当ててください。
+- 5W1H（いつ、どこで、誰が、何を、なぜ、どのように）を意識した要約を心がけてください。
+- 重要ポイントは3〜5項目程度に絞ってください。
+
+【出力形式】
+以下のJSON形式で出力してください。
+{{
+  "summary": "記事の内容を掴むための簡潔な要約（200〜300文字程度）。事実に基づいた具体的な内容にすること。",
+  "key_points": [
+    "重要ポイント1",
+    "重要ポイント2",
+    "重要ポイント3"
+  ]
+}}
+
+対象の記事テキスト:
+{article_text}
+"""
+        return self._generate_summary(prompt)
+
+    def _generate_summary(self, prompt: str) -> Dict:
+        """Gemini APIを呼び出して要約を生成する共通処理"""
         try:
             # プレフィックスなしで試行
             response = self.client.models.generate_content(

--- a/backend/youtube_client.py
+++ b/backend/youtube_client.py
@@ -39,7 +39,7 @@ class YouTubeClient:
 
         for entry in feed.entries:
             # 動画IDを抽出 (yt:videoId タグから)
-            video_id = entry.yt_videoid if hasattr(entry, 'yt_videoid') else None
+            video_id = entry.yt_videoid if hasattr(entry, "yt_videoid") else None
             if not video_id:
                 continue
 
@@ -50,7 +50,9 @@ class YouTubeClient:
                 continue
 
             # タイトルが「【ライブ】mm/dd 朝ニュースまとめ」「【ライブ】mm/dd 昼ニュースまとめ」「【ライブ】mm/dd 夜ニュースまとめ」のいずれかに一致するか確認
-            if not re.match(r"^【ライブ】\d{1,2}/\d{1,2}\s+(朝|昼|夜)ニュースまとめ", title):
+            if not re.match(
+                r"^【ライブ】\d{1,2}/\d{1,2}\s+(朝|昼|夜)ニュースまとめ", title
+            ):
                 continue
 
             # 未来の日付のニュースを除外する (タイトルに含まれる日付を確認)
@@ -86,14 +88,18 @@ class YouTubeClient:
             if video_id not in seen_ids:
                 # サムネイルURLを取得 (media:group > media:thumbnail)
                 thumbnail_url = None
-                if hasattr(entry, 'media_thumbnail'):
-                    thumbnail_url = entry.media_thumbnail[0]['url'] if entry.media_thumbnail else None
+                if hasattr(entry, "media_thumbnail"):
+                    thumbnail_url = (
+                        entry.media_thumbnail[0]["url"]
+                        if entry.media_thumbnail
+                        else None
+                    )
 
                 # 公開日時を取得
-                published_at = entry.published if hasattr(entry, 'published') else None
+                published_at = entry.published if hasattr(entry, "published") else None
 
                 # 説明文を取得
-                description = entry.summary if hasattr(entry, 'summary') else ""
+                description = entry.summary if hasattr(entry, "summary") else ""
 
                 videos.append(
                     {
@@ -123,12 +129,18 @@ class YouTubeClient:
             import requests
 
             session = requests.Session()
-            # 一般的なブラウザのUser-Agentを設定
-            session.headers.update(
-                {
-                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-                }
-            )
+            # ランダムなUser-Agentを選択してブロックを回避しやすくする
+            user_agents = [
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0",
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0",
+            ]
+            ua = random.choice(user_agents)
+            session.headers.update({"User-Agent": ua})
+            print(f"DEBUG: Using User-Agent: {ua}")
 
             cookies_path = "/app/cookies.txt"
             if os.path.exists(cookies_path):
@@ -151,22 +163,22 @@ class YouTubeClient:
             try:
                 # 1. 日本語字幕を優先 (手動・自動生成問わず)
                 transcript = transcript_list.find_transcript(["ja"])
-            except:
+            except Exception:
                 try:
                     # 2. 他の言語（英語など）があれば日本語に翻訳
                     transcript = transcript_list.find_transcript(["en"]).translate("ja")
-                except:
+                except Exception:
                     # 3. それでもダメなら、なんでもいいので日本語に翻訳を試みる
                     try:
                         transcript = list(
                             transcript_list._manually_created_transcripts.values()
                         )[0].translate("ja")
-                    except:
+                    except Exception:
                         try:
                             transcript = list(
                                 transcript_list._generated_transcripts.values()
                             )[0].translate("ja")
-                        except:
+                        except Exception:
                             print(
                                 f"No suitable transcript or translatable captions found for {video_id}"
                             )


### PR DESCRIPTION
## 概要
YouTubeのIPブロック問題（オラクルクラウドIPがYouTubeにブロックされ字幕取得不可）を回避するため、ニュースソースをNHK RSSフィードに変更しました。

## 変更点
### 新規追加
- `backend/nhk_client.py`: NHK RSSフィードからニュース記事を取得するクライアント
- `backend/database.py`: `Article`, `ArticleKeyPoint` モデルを追加

### 変更
- `backend/main.py`: NHKニュースベースの収集ロジックに変更。旧YouTube用エンドポイントは後方互換性のため残存
- `backend/summarizer.py`: 記事要約用の `summarize_article` メソッドを追加
- `backend/requirements.txt`: beautifulsoup4, lxml を追加
- `ansible/inventory/hosts.yml`: APIキーを環境変数から読み込むように変更（漏洩対策）

### セキュリティ対策
- 以前コミットされていたAPIキー（Gemini）はGoogleにより漏洩判定・無効化済み
- 今後はAPIキーをGitにコミットせず、サーバーの`.env`で直接管理

## テスト方法
1. コンテナ再ビルド: `docker compose build backend`
2. 起動: `docker compose up -d`
3. 収集実行: `curl -X POST http://localhost:8000/api/news/collect`
4. 確認: `curl http://localhost:8000/api/news/list`

Close #32