### PR TITLE
fix(backend): fix news scraping and Gemini safety filters

### DIFF
--- a/backend/nhk_client.py
+++ b/backend/nhk_client.py
@@ -134,6 +134,7 @@ class NHKNewsClient:
             # NHKニュースの記事本文を取得
             # 複数のセレクタを試す
             content_selectors = [
+                "div._1i1d7sh0",  # 最新のNHK ONEレイアウト
                 "div.content--detail-body",
                 "div.body-content",
                 "article",


### PR DESCRIPTION
## Changes from main
- **nhk_client.py**: Updated article content selectors to support the new NHK ONE layout. This fixes the issue where some articles had empty summaries because the body text couldn't be extracted.
- **summarizer.py**: Relaxed Gemini safety settings to `BLOCK_NONE` for all categories. This prevents war-related news (like the Russian attack on Kyiv) from being blocked by the AI's safety filters. 
- **main.py**: Improved error recovery. When a `429 RESOURCE_EXHAUSTED` error occurs, the system no longer saves a 'Failure' message to the database. Instead, it leaves the article as 'unprocessed' so it can be retried in the next background run.

## Verification Result
- Verified in the local browser (http://localhost/) that all 11 news articles, including the previously failing top news and war-related news, are now successfully summarized and displayed in Japanese.

Closes #34