### PR TITLE
fix: #39 正しいGemini 3モデルIDに修正

### DIFF
--- a/ansible/roles/app_deploy/templates/.env.j2
+++ b/ansible/roles/app_deploy/templates/.env.j2
@@ -5,6 +5,7 @@ DB_NAME={{ db_name | default("news_db") }}
 
 # External APIs
 GEMINI_API_KEY={{ gemini_api_key | default("") }}
+GEMINI_MODEL={{ gemini_model | default("gemini-3-flash-preview") }}
 YOUTUBE_API_KEY={{ youtube_api_key | default("") }}
 
 # Frontend

--- a/backend/summarizer.py
+++ b/backend/summarizer.py
@@ -12,7 +12,7 @@ class Summarizer:
     def __init__(self, api_key: str):
         self.client = genai.Client(api_key=api_key)
         # 現時点で動作とクォータが確認できた gemini-2.0-flash をデフォルトに使用
-        self.model_id = os.getenv("GEMINI_MODEL", "gemini-3-flash")
+        self.model_id = os.getenv("GEMINI_MODEL", "gemini-3-flash-preview")
 
     def summarize(self, transcript: str) -> Dict:
         """


### PR DESCRIPTION
## 概要
前回のPRで指定した  が無効なID（404）であったため、正しいIDである  に修正しました。

## 変更内容
- backend/summarizer.py, ansible テンプレートのモデルIDを修正
- ローカル環境での要約生成成功を確認済み

Close #39