### PR TITLE
chore: docker-compose の環境変数に GEMINI_MODEL を追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     environment:
       DATABASE_URL: postgresql://${DB_USER:-user}:${DB_PASSWORD:-password}@db:5432/${DB_NAME:-news_db}
       GEMINI_API_KEY: ${GEMINI_API_KEY}
+      GEMINI_MODEL: ${GEMINI_MODEL:-gemini-3-flash-preview}
       YOUTUBE_API_KEY: ${YOUTUBE_API_KEY}
       PYTHONUNBUFFERED: "1"
     depends_on:


### PR DESCRIPTION
## 概要
バックエンドでモデル ID を環境変数から取得できるようにするため、 に  を追加しました。

## 変更内容
- docker-compose.yml に GEMINI_MODEL を追加