### PR TITLE
feat: ドメイン設定（technohonesty.com）とSSL/TLS対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ Thumbs.db
 
 # Cookies
 backend/cookies.txt
+cookies.txt
+
+# Database
+backend/news.db

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -5,7 +5,8 @@ all:
     project_root: "/home/{{ ansible_user }}/git/news_check"
     gemini_api_key: "{{ lookup('env', 'GEMINI_API_KEY') | default('', true) }}"
     youtube_api_key: "{{ lookup('env', 'YOUTUBE_API_KEY') | default('', true) }}"
-    next_public_api_url: ""
+    domain_name: "technohonesty.com"
+    next_public_api_url: "https://{{ domain_name }}"
 
   children:
     # ローカル環境 (WSL)

--- a/ansible/roles/app_deploy/tasks/main.yml
+++ b/ansible/roles/app_deploy/tasks/main.yml
@@ -54,6 +54,22 @@
     job: "curl -s -X POST http://localhost:8000/api/news/collect >> /var/log/news_check/cron.log 2>&1"
     user: "{{ ansible_user }}"
 
+- name: Install Certbot
+  apt:
+    name:
+      - certbot
+      - python3-certbot-nginx
+    state: present
+  when: ansible_connection != 'local'
+
+- name: Create Nginx config from template
+  template:
+    src: nginx_default.conf.j2
+    dest: "{{ project_root }}/nginx/default.conf"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: "0644"
+
 - name: Start Docker Compose
   community.docker.docker_compose_v2:
     project_src: "{{ project_root }}"

--- a/ansible/roles/app_deploy/templates/nginx_default.conf.j2
+++ b/ansible/roles/app_deploy/templates/nginx_default.conf.j2
@@ -1,0 +1,51 @@
+server {
+    listen 80;
+    server_name {{ domain_name | default('localhost') }};
+
+    # Let's Encrypt validation
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    # Redirect all HTTP traffic to HTTPS
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name {{ domain_name | default('localhost') }};
+
+    ssl_certificate /etc/letsencrypt/live/{{ domain_name }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ domain_name }}/privkey.pem;
+
+    # SSL security settings
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+
+    # Docker DNS resolver
+    resolver 127.0.0.11 valid=30s;
+
+    # フロントエンドへのプロキシ
+    location / {
+        set $upstream_frontend frontend;
+        proxy_pass http://$upstream_frontend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # バックエンドAPIへのプロキシ
+    location /api/ {
+        set $upstream_backend backend;
+        proxy_pass http://$upstream_backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,8 +61,10 @@ services:
     container_name: news_check_nginx
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:
       - frontend
       - backend

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -137,3 +137,9 @@ variable "ssh_public_key" {
   type        = string
   default     = ""
 }
+
+variable "domain_name" {
+  description = "Domain name for the application (e.g., news-check.example.com)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## 概要
ニュース配信サービス「News Check」を  で公開し、HTTPSによる暗号化通信を有効にするための設定を追加しました。

## 変更内容
- **Terraform**:  変数の追加
- **Docker Compose**: 443ポートの開放とSSL証明書ボリュームのマウント
- **Nginx**: SSL/TLS対応のテンプレート作成と自動リダイレクト設定
- **Ansible**: Certbotのインストール、Nginx設定の自動反映、 の設定

## 本番適用手順
1. 本PRをマージ。
2. インスタンス上で  を実行（GitHub Actionsで実行される予定）。
3. **初回のみ**: 証明書を手動取得する必要があります。詳細は walkthrough.md を参照。

Close #45