### PR TITLE
fix: 本番環境の /news 404エラーを修正

### DIFF
--- a/ansible/roles/app_deploy/templates/nginx_default.conf.j2
+++ b/ansible/roles/app_deploy/templates/nginx_default.conf.j2
@@ -28,6 +28,11 @@ server {
     # Docker DNS resolver
     resolver 127.0.0.11 valid=30s;
 
+    # ルートからのリダイレクト
+    location = / {
+        return 301 https://$host/news;
+    }
+
     # フロントエンドへのプロキシ
     location /news {
         set $upstream_frontend frontend;
@@ -39,5 +44,13 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
-
+    # バックエンドAPIへの直接プロキシ (相対パス対応)
+    location /news/api/ {
+        set $upstream_backend backend;
+        proxy_pass http://$upstream_backend:8000/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,6 +22,7 @@ ENV NODE_ENV=production
 
 # 必要なファイルのみコピー
 COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/next.config.ts ./
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/node_modules ./node_modules


### PR DESCRIPTION
## 概要
本番環境で https://technohonesty.com/news が 404 エラーになる問題を修正します。

## 変更内容
- **Dockerfile**:  を runner ステージにコピーするように修正。これにより、本番環境でも  設定が有効になります。
- **Nginx 設定**:
    - ルート  へのアクセスを  にリダイレクトするように追加。
    -  への直接プロキシ設定を追加し、バックエンド通信を安定化。

Close #123