### PR TITLE
fix: ニュースが表示されない問題の修正 (#54)

### DIFF
--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -6,7 +6,7 @@ all:
     gemini_api_key: "{{ lookup('env', 'GEMINI_API_KEY') | default('', true) }}"
     youtube_api_key: "{{ lookup('env', 'YOUTUBE_API_KEY') | default('', true) }}"
     domain_name: "technohonesty.com"
-    next_public_api_url: "https://{{ domain_name }}"
+    next_public_api_url: "https://{{ domain_name }}/news"
 
   children:
     # ローカル環境 (WSL)

--- a/ansible/roles/app_deploy/handlers/main.yml
+++ b/ansible/roles/app_deploy/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart Nginx
+  community.docker.docker_compose_v2:
+    project_src: "{{ project_root }}"
+    services:
+      - nginx
+    state: restarted

--- a/ansible/roles/app_deploy/tasks/main.yml
+++ b/ansible/roles/app_deploy/tasks/main.yml
@@ -69,6 +69,7 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: "0644"
+  notify: Restart Nginx
 
 - name: Start Docker Compose
   community.docker.docker_compose_v2:

--- a/ansible/roles/app_deploy/templates/nginx_default.conf.j2
+++ b/ansible/roles/app_deploy/templates/nginx_default.conf.j2
@@ -44,13 +44,4 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
-    # バックエンドAPIへの直接プロキシ (相対パス対応)
-    location /news/api/ {
-        set $upstream_backend backend;
-        proxy_pass http://$upstream_backend:8000/api/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
 }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,8 +9,6 @@ RUN npm install
 
 # ソースコードのコピーとビルド
 COPY . .
-# 外部からのAPI通信を相対パスで行うため、空文字をセット（Nginx経由前提）
-ENV NEXT_PUBLIC_API_URL=""
 RUN npm run build
 
 # Production stage

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -14,13 +14,14 @@ function NewsContent() {
 
   // URLクエリパラメータから日付を取得 (YYYY-MM-DD)
   const dateParam = searchParams.get('date');
-
   const fetchDailyDigest = async (targetDate?: string) => {
     try {
       setIsLoading(true);
-      const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? '';
 
-      let url = `${apiUrl}/api/news/daily`;
+      // 本番環境（basePath='/news'）での相対パス対応
+      const apiPath = apiUrl ? `${apiUrl}/api` : '/news/api';
+      let url = `${apiPath}/news/daily`;
       if (targetDate) {
         url += `?target_date=${targetDate}`;
       }


### PR DESCRIPTION
Close #54\n\n- APIキーの欠落を修正 (Ansibleインベントリで環境変数を参照)\n- フロントエンドのAPIパスを /news/api/... に修正\n- Dockerfile での NEXT_PUBLIC_API_URL のハードコードを解除\n- Ansible に Nginx 再起動ハンドラを追加