### PR TITLE
chore: ルートからのリダイレクトを解除 (#56)

### DIFF
--- a/ansible/roles/app_deploy/templates/nginx_default.conf.j2
+++ b/ansible/roles/app_deploy/templates/nginx_default.conf.j2
@@ -28,11 +28,6 @@ server {
     # Docker DNS resolver
     resolver 127.0.0.11 valid=30s;
 
-    # ルートからのリダイレクト
-    location = / {
-        return 301 https://$host/news;
-    }
-
     # フロントエンドへのプロキシ
     location /news {
         set $upstream_frontend frontend;


### PR DESCRIPTION
Close #56\n\nhttps://technohonesty.com から /news へのリダイレクト設定を削除しました。